### PR TITLE
Set configured AF_XDP socket bind flags even when Umem is not shared

### DIFF
--- a/src/xsk/umem.rs
+++ b/src/xsk/umem.rs
@@ -272,6 +272,7 @@ impl Umem {
         let mut sxdp = SockAddrXdp {
             ifindex: interface.socket.info.ctx.ifindex,
             queue_id: interface.socket.info.ctx.queue_id,
+            flags: interface.config.bind_flags,
             ..SockAddrXdp::default()
         };
 
@@ -279,7 +280,7 @@ impl Umem {
         // the interface indicated.
 
         if interface.socket.fd.0 != umem_sock.0 {
-            sxdp.flags = interface.config.bind_flags | SocketConfig::XDP_BIND_SHARED_UMEM;
+            sxdp.flags |= SocketConfig::XDP_BIND_SHARED_UMEM;
             sxdp.shared_umem_fd = umem_sock.0 as u32;
         }
 


### PR DESCRIPTION
Previously, the user's configured `SocketConfig::bind_flags` value was ignored when binding the AF_XDP socket unless the Umem was shared across multiple sockets. The configured bind flags should be used even when the Umem is not shared.