### PR TITLE
fix: remove zero copy flag in example flood, add docs

### DIFF
--- a/examples/flood.rs
+++ b/examples/flood.rs
@@ -34,7 +34,7 @@ fn main() {
             &SocketConfig {
                 rx_size: None,
                 tx_size: NonZeroU32::new(1 << 14),
-                bind_flags: SocketConfig::XDP_BIND_ZEROCOPY | SocketConfig::XDP_BIND_NEED_WAKEUP,
+                bind_flags: SocketConfig::XDP_BIND_NEED_WAKEUP,
             },
         )
         .unwrap();

--- a/src/xsk/umem.rs
+++ b/src/xsk/umem.rs
@@ -431,6 +431,7 @@ impl SocketConfig {
     /// Force copy-mode.
     pub const XDP_BIND_COPY: u16 = 1 << 1;
     /// Force zero-copy-mode.
+    /// check if your NIC supports zero-copy mode by searching `XDP_SETUP_XSK_POOL` in linux kernel source code.
     pub const XDP_BIND_ZEROCOPY: u16 = 1 << 2;
     /// Enable support for need wakeup.
     ///


### PR DESCRIPTION
## background

`XDP_BIND_ZEROCOPY` flag is pretty picky of the NIC, it's not widely supported, so it might be better to disable it in example code.

here is all the NICs that supports `XDP_BIND_ZEROCOPY` (through `XDP_SETUP_XSK_POOL` command)

![image](https://github.com/user-attachments/assets/c0085376-1a52-45ef-9e71-9eafe474f5e7)

here is the [link to the linux kernel source code](https://github.com/torvalds/linux/blob/f4ce1f3318ad4bc12463698696ebc36b145a6aa3/net/xdp/xsk_buff_pool.c#L218) that are very likely to cause trouble for `bind` operation